### PR TITLE
Call gtk_widget_show_all() on a StatusIcon before binding to the proxy's visible property.

### DIFF
--- a/plugin/status-icon.c
+++ b/plugin/status-icon.c
@@ -289,12 +289,12 @@ status_icon_new (XAppStatusIconInterface *proxy)
     StatusIcon *icon = g_object_new (STATUS_TYPE_ICON, NULL);
     icon->proxy = g_object_ref (proxy);
 
+    gtk_widget_show_all (GTK_WIDGET (icon));
+
     bind_props_and_signals (icon);
 
     update_orientation (icon);
     update_image (icon);
-
-    gtk_widget_show_all (GTK_WIDGET (icon));
 
     return icon;
 }

--- a/plugin/xapp-status-plugin.c
+++ b/plugin/xapp-status-plugin.c
@@ -141,7 +141,6 @@ on_icon_added (XAppStatusIconMonitor        *monitor,
     }
 
     icon = status_icon_new (proxy);
-    gtk_widget_show (GTK_WIDGET (icon));
 
     gtk_container_add (GTK_CONTAINER (plugin->icon_box),
                        GTK_WIDGET (icon));


### PR DESCRIPTION
The binding is one way only - local changes can override the state initially set by the proxy.